### PR TITLE
Update platform interface to avoid using a `const` token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.0] - 2022-01-06
+
+* Updated to depend on plugin_platform_interface 2.1.0.
+* Updated plugin platform interface to use a non`-const` token. This is marked as a breaking change because it can cause an assertion failure if implementations use `extends` rather than `implements`, but hopefully there aren't any of those.
+
 ## [0.5.0] - 2020-12-28
 
 **Breaking changes**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.6.0] - 2022-01-06
 
 * Updated to depend on plugin_platform_interface 2.1.0.
-* Updated plugin platform interface to use a non`-const` token. This is marked as a breaking change because it can cause an assertion failure if implementations use `extends` rather than `implements`, but hopefully there aren't any of those.
+* Updated plugin platform interface to use a non`-const` token. This is marked as a breaking change because it can cause an assertion failure if implementations use `implements` rather than `extends`, but hopefully there aren't any of those.
 
 ## [0.5.0] - 2020-12-28
 

--- a/lib/uni_links_platform_interface.dart
+++ b/lib/uni_links_platform_interface.dart
@@ -12,7 +12,7 @@ import 'method_channel_uni_links.dart';
 abstract class UniLinksPlatform extends PlatformInterface {
   /// A token used for verification of subclasses to ensure they extend this
   /// class instead of implementing it.
-  static const _token = Object();
+  static final Object _token = Object();
 
   /// Constructs a [UniLinksPlatform].
   UniLinksPlatform() : super(token: _token);
@@ -28,7 +28,7 @@ abstract class UniLinksPlatform extends PlatformInterface {
   /// platform-specific class that extends [UniLinksPlatform] when they register
   /// themselves.
   static set instance(UniLinksPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/avioli/uni_links/tree/master/uni_links
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 
 dev_dependencies:


### PR DESCRIPTION
Due to a mistake in the documentation (now fixed) `UniLinksPlatform` can be implemented with `implements` rather than `extends`. This PR fixes the issue.

### References

Flutter issue: flutter/flutter#96178
PR that updated plugin_platform_interface: flutter/plugins#4640
PR that updated Flutter plugins: flutter/plugins#4643